### PR TITLE
Rename getRresignUrl to getPresignUrl

### DIFF
--- a/controllers/quizController.js
+++ b/controllers/quizController.js
@@ -18,7 +18,7 @@ exports.createQuizBasic = async (req, res) => {
 
         const quiz_id = result[0].insertId.toString();
         // s3 pre-signed URL 생성
-        const s3_url = await imgDb.getRresignUrl(quiz_id, mime_type);
+        const s3_url = await imgDb.getPresignUrl(quiz_id, mime_type);
         res.status(201).json({
             "success": true,
             "content": JSON.stringify({

--- a/servers/ImgServer.js
+++ b/servers/ImgServer.js
@@ -25,7 +25,8 @@ const s3 = new AWS.S3();
 //     }
 // });
 
-exports.getRresignUrl = async (key, mimeType) => {
+// Return a pre-signed URL for uploading an image to S3
+exports.getPresignUrl = async (key, mimeType) => {
     try {
         const url = s3.getSignedUrl('putObject', {
             Bucket: process.env.AWS_S3_BUCKET_NAME,
@@ -63,6 +64,6 @@ exports.uploadImage = async (filePath, keyName) => {
 }
 
 
-//module.exports = { getRresignUrl };
+//module.exports = { getPresignUrl };
 //uploadImage("testImage.png", "test.jpg");
 


### PR DESCRIPTION
## Summary
- rename `getRresignUrl` API in `ImgServer` to `getPresignUrl`
- update quiz controller to use new `getPresignUrl`
- adjust comments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683fa5d7e5648331b95809f242fb2ca7